### PR TITLE
fixed artifactory plugin for 7.x version

### DIFF
--- a/cleanup/artifactCleanup/artifactCleanup.groovy
+++ b/cleanup/artifactCleanup/artifactCleanup.groovy
@@ -19,12 +19,19 @@ import java.util.regex.Pattern
 
 import org.apache.commons.lang3.StringUtils
 import org.artifactory.api.repo.exception.ItemNotFoundRuntimeException
+import org.artifactory.exception.CancelException
 
+import groovy.json.JsonSlurper
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
 import groovy.transform.Field
 
+import java.text.SimpleDateFormat
+
+@Field final String CONFIG_FILE_PATH = "plugins/${this.class.name}.json"
 @Field final String PROPERTIES_FILE_PATH = "plugins/${this.class.name}.properties"
+@Field final String DEFAULT_TIME_UNIT = "month"
+@Field final int DEFAULT_TIME_INTERVAL = 1
 
 class Global {
     static Boolean stopCleaning = false
@@ -32,8 +39,8 @@ class Global {
     static int paceTimeMS = 0
 }
 
-// curl command example for running this plugin (Prior Artifactory 5.x, use pipe '|' and not semi-colons ';' for parameters separation).
-// curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=months=1;repos=libs-release-local;dryRun=true;paceTimeMS=2000;disablePropertiesSupport=true;keepArtifacts=true"
+// curl command example for running this plugin (Prior to Artifactory 5.x, use pipe '|' and not semi-colons ';' for parameters separation).
+// curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanup?params=timeUnit=day;timeInterval=1;repos=libs-release-local;dryRun=true;paceTimeMS=2000;disablePropertiesSupport=true"
 //
 // For a HA cluster, the following commands have to be directed at the instance running the script. Therefore it is best to invoke
 // the script directly on an instance so the below commands can operate on same instance
@@ -42,22 +49,29 @@ class Global {
 // curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanupCtl?params=command=stop"
 // curl -i -uadmin:password -X POST "http://localhost:8081/artifactory/api/plugins/execute/cleanupCtl?params=command=adjustPaceTimeMS;value=-1000"
 
-
 def pluginGroup = 'cleaners'
-def config = new ConfigSlurper().parse(new File(ctx.artifactoryHome.haAwareEtcDir, PROPERTIES_FILE_PATH).toURL())
-def regex = ~/.*-[\.\d+]*[-+][\.\d+]*\..*/
-
+regex = ~/.*-[\.\d+]*[-+][\.\d+]*\..*/
 
 executions {
     cleanup(groups: [pluginGroup]) { params ->
-        def months = params['months'] ? params['months'][0] as int : 6
+        def timeUnit = params['timeUnit'] ? params['timeUnit'][0] as String : DEFAULT_TIME_UNIT
+        def timeInterval = params['timeInterval'] ? params['timeInterval'][0] as int : DEFAULT_TIME_INTERVAL
         def repos = params['repos'] as String[]
-        def dryRun = params['dryRun'] ? params['dryRun'][0].toBoolean() : false      
-        def disablePropertiesSupport = params['disablePropertiesSupport'] ? params['disablePropertiesSupport'][0].toBoolean() : false
-        Global.paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0
-        def keepArtifacts = params['keepArtifacts'] ? params['keepArtifacts'][0].toBoolean() : false
+        def dryRun = params['dryRun'] ? new Boolean(params['dryRun'][0]) : false
+        def disablePropertiesSupport = params['disablePropertiesSupport'] ? new Boolean(params['disablePropertiesSupport'][0]) : false
+        def paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0
+        def keepArtifacts = params['keepArtifacts'] ? new Boolean(params['keepArtifacts'][0]) : false
         def keepArtifactsRegex = params['keepArtifactsRegex'] ? params['keepArtifactsRegex'] as Pattern : regex
-        artifactCleanup(months, repos, log, Global.paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex)
+        
+        // Enable fallback support for deprecated month parameter
+        if ( params['months'] && !params['timeInterval'] ) {
+            log.info('Deprecated month parameter is still in use, please use the new timeInterval parameter instead!', properties)
+            timeInterval = params['months'][0] as int
+        } else if ( params['months'] ) {
+            log.warn('Deprecated month parameter and the new timeInterval are used in parallel: month has been ignored.', properties)
+        }
+
+        artifactCleanup(timeUnit, timeInterval, repos, log, paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex)
     }
 
     cleanupCtl(groups: [pluginGroup]) { params ->
@@ -70,8 +84,9 @@ executions {
                 break
             case "adjustPaceTimeMS":
                 def adjustPaceTimeMS = params['value'] ? params['value'][0] as int : 0
-                Global.paceTimeMS += adjustPaceTimeMS
-                log.info "Pacing adjustment request detected, adjusting pace time by $adjustPaceTimeMS to new value of $Global.paceTimeMS"
+                def newPaceTimeMS = ((Global.paceTimeMS + adjustPaceTimeMS) > 0) ? (Global.paceTimeMS + adjustPaceTimeMS) : 0
+                log.info "Pacing adjustment request detected, adjusting old pace time ($Global.paceTimeMS) by $adjustPaceTimeMS to new value of $newPaceTimeMS"
+                Global.paceTimeMS = newPaceTimeMS
                 break
             case "pause":
                 Global.pauseCleaning = true
@@ -87,38 +102,86 @@ executions {
     }
 }
 
-config.policies.each{ policySettings ->
-    def cron = policySettings[ 0 ] ? policySettings[ 0 ] as String : ["0 0 5 ? * 1"]
-    def repos = policySettings[ 1 ] ? policySettings[ 1 ] as String[] : ["__none__"]
-    def months = policySettings[ 2 ] ? policySettings[ 2 ] as int : 6
-    def paceTimeMS = policySettings[ 3 ] ? policySettings[ 3 ] as int : 0
-    def dryRun = policySettings[ 4 ] ? policySettings[ 4 ] as Boolean : false
-    def disablePropertiesSupport = policySettings[ 5 ] ? policySettings[ 5 ] as Boolean : false
-    def keepArtifacts = policySettings[ 6 ] ? policySettings[ 6 ] as Boolean : false
-    def keepArtifactsRegex = policySettings[ 7 ] ? policySettings[ 7 ] as Pattern : regex
+def deprecatedConfigFile = new File(ctx.artifactoryHome.etcDir, PROPERTIES_FILE_PATH)
+def configFile = new File(ctx.artifactoryHome.etcDir, CONFIG_FILE_PATH)
 
-    log.info "Schedule job policy list: $config.policies"
-    log.info "Schedule regex: $keepArtifactsRegex"
+if ( deprecatedConfigFile.exists() ) {
 
-    jobs {
-        "scheduledCleanup_$cron"(cron: cron) {
-            log.info "Policy settings for scheduled run at($cron): repo list($repos), months($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport) keepArtifacts($keepArtifacts), keepArtifactsRegex($keepArtifactsRegex)"
-            artifactCleanup( months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex )
+    if ( !configFile.exists() ) {
+        def config = new ConfigSlurper().parse(deprecatedConfigFile.toURL())
+        log.info "Schedule job policy list: $config.policies"
+
+        def count=1
+        config.policies.each{ policySettings ->
+            def cron = policySettings[ 0 ] ? policySettings[ 0 ] as String : ["0 0 5 ? * 1"]
+            def repos = policySettings[ 1 ] ? policySettings[ 1 ] as String[] : ["__none__"]
+            def months = policySettings[ 2 ] ? policySettings[ 2 ] as int : 6
+            def paceTimeMS = policySettings[ 3 ] ? policySettings[ 3 ] as int : 0
+            def dryRun = policySettings[ 4 ] ? policySettings[ 4 ] as Boolean : false
+            def disablePropertiesSupport = policySettings[ 5 ] ? policySettings[ 5 ] as Boolean : false
+            def keepArtifacts = policySettings[ 6 ] ? policySettings[ 6 ] as Boolean : false
+            def keepArtifactsRegex = policySettings[ 7 ] ? policySettings[ 7 ] as Pattern : regex
+
+            jobs {
+                "scheduledCleanup_$count"(cron: cron) {
+                    log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit(month), timeInterval($months), paceTimeMS($paceTimeMS), dryrun($dryRun), disablePropertiesSupport($disablePropertiesSupport), keepArtifacts($keepArtifacts), keepArtifactsRegex($keepArtifactsRegex)"
+                    artifactCleanup( "month", months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex )
+                }
+            }
+            count++
         }
+    } else  {
+        log.warn "Deprecated 'artifactCleanup.properties' file is still present, but ignored. You should remove the file."
     }
 }
 
-private def artifactCleanup(int months, String[] repos, log, paceTimeMS, dryRun = false, disablePropertiesSupport = false, keepArtifacts = false, keepArtifactsRegex = regex) {
-    log.info "Starting artifact cleanup for repositories $repos, until $months months ago with pacing interval $paceTimeMS ms, dryrun: $dryRun, disablePropertiesSupport: $disablePropertiesSupport, keepArtifacts: $keepArtifacts, keepArtifactsRegex: $keepArtifactsRegex"
+if ( configFile.exists() ) {
+  
+    def config = new JsonSlurper().parse(configFile.toURL())
+    log.info "Schedule job policy list: $config.policies"
+    log.info "Schedule regex: $keepArtifactsRegex"
 
-    // Create Map(repo, paths) of skipped paths (or other properties supported in future ...)
+    def count=1
+    config.policies.each{ policySettings ->
+        def cron = policySettings.containsKey("cron") ? policySettings.cron as String : ["0 0 5 ? * 1"]
+        def repos = policySettings.containsKey("repos") ? policySettings.repos as String[] : ["__none__"]
+        def timeUnit = policySettings.containsKey("timeUnit") ? policySettings.timeUnit as String : DEFAULT_TIME_UNIT
+        def timeInterval = policySettings.containsKey("timeInterval") ? policySettings.timeInterval as int : DEFAULT_TIME_INTERVAL
+        def paceTimeMS = policySettings.containsKey("paceTimeMS") ? policySettings.paceTimeMS as int : 0
+        def dryRun = policySettings.containsKey("dryRun") ? new Boolean(policySettings.dryRun) : false
+        def disablePropertiesSupport = policySettings.containsKey("disablePropertiesSupport") ? new Boolean(policySettings.disablePropertiesSupport) : false
+        def keepArtifacts = policySettings.containsKey("keepArtifacts") ? new Boolean(policySettings.keepArtifacts) : false
+        def keepArtifactsRegex = policySettings.containsKey("keepArtifactsRegex") ? policySettings.keepArtifactsRegex as Pattern : regex
+
+        jobs {
+            "scheduledCleanup_$count"(cron: cron) {
+                log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit($timeUnit), timeInterval($timeInterval), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport), keepArtifacts($keepArtifacts), keepArtifactsRegex($keepArtifactsRegex)"
+                artifactCleanup( timeUnit, timeInterval, repos, log, paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex )
+            }
+        }
+        count++
+    }  
+}
+
+if ( deprecatedConfigFile.exists() && configFile.exists() ) {
+    log.warn "The deprecated artifactCleanup.properties and the new artifactCleanup.json are defined in parallel. You should migrate the old file and remove it."
+}
+
+private def artifactCleanup(String timeUnit, int timeInterval, String[] repos, log, paceTimeMS, dryRun = false, disablePropertiesSupport = false, keepArtifacts = false, keepArtifactsRegex = regex) {
+    log.info "Starting artifact cleanup for repositories $repos, until $timeInterval ${timeUnit}s ago with pacing interval $paceTimeMS ms, dryrun: $dryRun, disablePropertiesSupport: $disablePropertiesSupport, keepArtifacts: $keepArtifacts, keepArtifactsRegex: $keepArtifactsRegex"
+
+    // Create Map(repo, paths) of skiped paths (or others properties supported in future ...)
     def skip = [:]
     if ( ! disablePropertiesSupport && repos){
         skip = getSkippedPaths(repos)
     }
 
-    def monthsUntil = Calendar.getInstance()
-    monthsUntil.add(Calendar.MONTH, -months)
+    def calendarUntil = Calendar.getInstance()
+
+    calendarUntil.add(mapTimeUnitToCalendar(timeUnit), -timeInterval)
+
+    def calendarUntilFormatted = new SimpleDateFormat("yyyy/MM/dd HH:mm").format(calendarUntil.getTime());
+    log.info "Removing all artifacts not downloaded since $calendarUntilFormatted"
 
     Global.stopCleaning = false
     int cntFoundArtifacts = 0
@@ -129,7 +192,7 @@ private def artifactCleanup(int months, String[] repos, log, paceTimeMS, dryRun 
     long bytesFoundWithNoDeletePermission = 0
     long bytesFoundWithRegexProtection = 0
     long bytesRemoved = 0
-    def artifactsCleanedUp = searches.artifactsNotDownloadedSince(monthsUntil, monthsUntil, repos)
+    def artifactsCleanedUp = searches.artifactsNotDownloadedSince(calendarUntil, calendarUntil, repos)
     artifactsCleanedUp.find {
         try {
             while ( Global.pauseCleaning ) {
@@ -156,12 +219,12 @@ private def artifactCleanup(int months, String[] repos, log, paceTimeMS, dryRun 
                 cntNoDeletePermissions++
             }
             if (dryRun) {
-                    log.debug "Found $it, $cntFoundArtifacts/$artifactsCleanedUp.size total $bytesFound bytes"
-                    log.debug "\t==> currentUser: ${security.currentUser().getUsername()}"
-                    log.debug "\t==> canDelete: ${security.canDelete(it)}"
-                    if (!checkName(keepArtifacts, keepArtifactsRegex, it)) {
+                log.debug "Found $it, $cntFoundArtifacts/$artifactsCleanedUp.size total $bytesFound bytes"
+                log.debug "\t==> currentUser: ${security.currentUser().getUsername()}"
+                log.debug "\t==> canDelete: ${security.canDelete(it)}"
+                if (!checkName(keepArtifacts, keepArtifactsRegex, it)) {
                         log.info "\t==> protected by regex: ${keepArtifactsRegex}"
-                    }
+                }
             } else {
                 if (security.canDelete(it) && (checkName(keepArtifacts, keepArtifactsRegex, it))) {
                     bytesRemoved += repositories.getItemInfo(it)?.getSize()
@@ -193,11 +256,15 @@ private def artifactCleanup(int months, String[] repos, log, paceTimeMS, dryRun 
 
     if (dryRun) {
         log.info "Dry run - nothing deleted. Found $cntFoundArtifacts artifacts consuming $bytesFound bytes"
-        log.info "From that $cntNoDeletePermissions artifacts no delete permission by user ($bytesFoundWithNoDeletePermission bytes)"
+        if (cntNoDeletePermissions > 0) {
+            log.info "$cntNoDeletePermissions artifacts cannot be deleted due to lack of permissions ($bytesFoundWithNoDeletePermission bytes)"
+        }
     } else {
         cntRemovedArtifacts = cntFoundArtifacts - cntNoDeletePermissions - cntNoDeleteRegexPermissions
-        log.info "Finished cleanup $repos repositories, try to delete $cntFoundArtifacts artifacts that took up $bytesFound bytes"
-        log.info "From that $cntNoDeletePermissions artifacts no delete permission by user ($bytesFoundWithNoDeletePermission bytes)"
+        log.info "Finished cleanup $repos repositories, deleting $cntFoundArtifacts artifacts that took up $bytesFound bytes"
+        if (cntNoDeletePermissions > 0) {
+            log.info "$cntNoDeletePermissions artifacts could not be deleted due to lack of permissions ($bytesFoundWithNoDeletePermission bytes)"
+        }
         log.info "and $cntNoDeleteRegexPermissions artifacts is protected by regex $keepArtifactsRegex ($bytesFoundWithRegexProtection bytes)"
         log.info "After this cleanup, $cntRemovedArtifacts artifacts ($bytesRemoved bytes) was removed from $repos repositories"
     }
@@ -245,6 +312,25 @@ private def getSkippedPaths(String[] repos) {
     TimeDuration duration = TimeCategory.minus(timeStop, timeStart)
     log.info "Elapsed time to retrieve paths to skip: " + duration
     return skip
+}
+
+private def mapTimeUnitToCalendar (String timeUnit) {
+    switch ( timeUnit ) {
+        case "minute":
+            return Calendar.MINUTE
+        case "hour":
+            return Calendar.HOUR
+        case "day":
+            return Calendar.DAY_OF_YEAR
+        case "month":
+            return Calendar.MONTH
+        case "year":
+            return Calendar.YEAR
+        default:
+            def errorMessage = "$timeUnit is no valid time unit. Please check your request or scheduled policy."
+            log.error errorMessage
+            throw new CancelException(errorMessage, 400)
+    }
 }
 
 private def checkName(keepArtifacts, keepArtifactsRegex, artifactName) {

--- a/cleanup/deleteEmptyDirs/deleteEmptyDirs.groovy
+++ b/cleanup/deleteEmptyDirs/deleteEmptyDirs.groovy
@@ -46,7 +46,7 @@ executions {
     }
 }
 
-def config = new ConfigSlurper().parse(new File(ctx.artifactoryHome.haAwareEtcDir, PROPERTIES_FILE_PATH).toURL())
+def config = new ConfigSlurper().parse(new File(ctx.artifactoryHome.etcDir, PROPERTIES_FILE_PATH).toURL())
 log.info "Schedule job policy list: $config.policies"
 
 config.policies.each{ policySettings ->


### PR DESCRIPTION
Comments for previous PR:
In cleanup/artifactCleanup/artifactCleanup.groovy:

>          def repos = params['repos'] as String[]
-        def dryRun = params['dryRun'] ? params['dryRun'][0].toBoolean() : false      
-        def disablePropertiesSupport = params['disablePropertiesSupport'] ? params['disablePropertiesSupport'][0].toBoolean() : false
-        Global.paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0
-        def keepArtifacts = params['keepArtifacts'] ? params['keepArtifacts'][0].toBoolean() : false
+        def dryRun = params['dryRun'] ? new Boolean(params['dryRun'][0]) : false
+        def disablePropertiesSupport = params['disablePropertiesSupport'] ? new Boolean(params['disablePropertiesSupport'][0]) : false
+        def paceTimeMS = params['paceTimeMS'] ? params['paceTimeMS'][0] as int : 0
+        def keepArtifacts = params['keepArtifacts'] ? new Boolean(params['keepArtifacts'][0]) : false
+        // def keepArtifacts = params['keepArtifacts'] ? params['keepArtifacts'][0].toBoolean() : false
Commented out code: Please remove

In cleanup/artifactCleanup/artifactCleanup.groovy:

>      log.info "Schedule job policy list: $config.policies"
     log.info "Schedule regex: $keepArtifactsRegex"
 
-    jobs {
-        "scheduledCleanup_$cron"(cron: cron) {
-            log.info "Policy settings for scheduled run at($cron): repo list($repos), months($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport) keepArtifacts($keepArtifacts), keepArtifactsRegex($keepArtifactsRegex)"
-            artifactCleanup( months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex )
+    def count=1
+    config.policies.each{ policySettings ->
+        def cron = policySettings.containsKey("cron") ? policySettings.cron as String : ["0 0 5 ? * 1"]
+        def repos = policySettings.containsKey("repos") ? policySettings.repos as String[] : ["__none__"]
+        def timeUnit = policySettings.containsKey("timeUnit") ? policySettings.timeUnit as String : DEFAULT_TIME_UNIT
+        def timeInterval = policySettings.containsKey("timeInterval") ? policySettings.timeInterval as int : DEFAULT_TIME_INTERVAL
+        def paceTimeMS = policySettings.containsKey("paceTimeMS") ? policySettings.paceTimeMS as int : 0
+        def dryRun = policySettings.containsKey("dryRun") ? new Boolean(policySettings.dryRun) : false
+        def disablePropertiesSupport = policySettings.containsKey("disablePropertiesSupport") ? new Boolean(policySettings.disablePropertiesSupport) : false
+
Missing parameters keepArtifacts and keepArtifactsRegex

In cleanup/artifactCleanup/artifactCleanup.groovy:

>  
+            jobs {
+                "scheduledCleanup_$count"(cron: cron) {
+                    log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit(month), timeInterval($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport)"
+                    artifactCleanup( "month", months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport )
Parameters keepArtifacts and keepArtifactsRegex missing in invocation

In cleanup/artifactCleanup/artifactCleanup.groovy:

>  
+            jobs {
+                "scheduledCleanup_$count"(cron: cron) {
+                    log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit(month), timeInterval($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport)"
keepArtifacts and keepArtifactsRegex should be dumped as well in this log message

In cleanup/artifactCleanup/artifactCleanup.groovy:

> -        "scheduledCleanup_$cron"(cron: cron) {
-            log.info "Policy settings for scheduled run at($cron): repo list($repos), months($months), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport) keepArtifacts($keepArtifacts), keepArtifactsRegex($keepArtifactsRegex)"
-            artifactCleanup( months, repos, log, paceTimeMS, dryRun, disablePropertiesSupport, keepArtifacts, keepArtifactsRegex )
+    def count=1
+    config.policies.each{ policySettings ->
+        def cron = policySettings.containsKey("cron") ? policySettings.cron as String : ["0 0 5 ? * 1"]
+        def repos = policySettings.containsKey("repos") ? policySettings.repos as String[] : ["__none__"]
+        def timeUnit = policySettings.containsKey("timeUnit") ? policySettings.timeUnit as String : DEFAULT_TIME_UNIT
+        def timeInterval = policySettings.containsKey("timeInterval") ? policySettings.timeInterval as int : DEFAULT_TIME_INTERVAL
+        def paceTimeMS = policySettings.containsKey("paceTimeMS") ? policySettings.paceTimeMS as int : 0
+        def dryRun = policySettings.containsKey("dryRun") ? new Boolean(policySettings.dryRun) : false
+        def disablePropertiesSupport = policySettings.containsKey("disablePropertiesSupport") ? new Boolean(policySettings.disablePropertiesSupport) : false
+
+        jobs {
+            "scheduledCleanup_$count"(cron: cron) {
+                log.info "Policy settings for scheduled run at($cron): repo list($repos), timeUnit($timeUnit), timeInterval($timeInterval), paceTimeMS($paceTimeMS) dryrun($dryRun) disablePropertiesSupport($disablePropertiesSupport)"
keepArtifacts and keepArtifactsRegex not printed